### PR TITLE
Panic macro for Crust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 main
+main-macos

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,33 @@
-main: main.o
-	gcc -o main  -L./raylib-5.5_linux_amd64/lib/ main.o -l:libraylib.a -lm
+# Variables
+RAYLIB_PATH_LINUX = ./raylib-5.5_linux_amd64/lib/
+RAYLIB_PATH_MACOS = ./raylib-5.5_macos/lib/
+RAYLIB_LIB = libraylib.a
+CFLAGS = -lm
+RUSTFLAGS = --edition 2021 -g -C opt-level=z --emit=obj -C panic="abort"
+SRC = main.rs
+OBJ = main.o
 
-main.o: main.rs
-	rustc --edition 2021 -g -C opt-level=z --emit=obj -C panic="abort" main.rs
+# Platform-specific settings
+ifeq ($(shell uname), Darwin) # macOS
+    PLATFORM = macos
+    EXTRA_FLAGS = -framework CoreVideo -framework IOKit -framework Cocoa -framework GLUT -framework OpenGL
+	LINK_FLAGS = -L$(RAYLIB_PATH) $(RAYLIB_PATH)$(RAYLIB_LIB)
+    RAYLIB_PATH = $(RAYLIB_PATH_MACOS)
+else # Linux
+    PLATFORM = linux
+    EXTRA_FLAGS =
+	LINK_FLAGS = -L$(RAYLIB_PATH) -l:$(RAYLIB_LIB)
+    RAYLIB_PATH = $(RAYLIB_PATH_LINUX)
+endif
+
+# Targets
+main: $(OBJ)
+	gcc -o $@ $(OBJ) $(CFLAGS) $(EXTRA_FLAGS) $(LINK_FLAGS)
+
+$(OBJ): $(SRC)
+	rustc $(RUSTFLAGS) $<
+
+# Phony targets
+.PHONY: clean
+clean:
+	rm -f $(OBJ) main

--- a/main.rs
+++ b/main.rs
@@ -62,6 +62,50 @@ mod libc {
     use core::ffi::{c_void};
 
     #[macro_export]
+    macro_rules! panic {
+        () => {
+            {
+                use core::ffi::c_int;
+                use core::panic::Location;
+                extern "C" {
+                    #[link_name = "exit"]
+                    pub fn exit_raw(code: c_int) -> !;
+
+                    #[link_name = "printf"]
+                    pub fn printf_raw(fmt: *const u8, ...) -> c_int;
+                }
+                // Get the location of the function that called panic
+                let loc = Location::caller();
+                let file = loc.file();
+                let line = loc.line();
+                let col  = loc.column();
+                printf_raw(b"%.*s:%u:%u: ERROR\n\0".as_ptr(), file.len(), file.as_ptr(), line, col);
+                exit_raw(69)
+            }
+        };
+        ($fmt:literal) => {
+            {
+                use core::ffi::c_int;
+                use core::panic::Location;
+                extern "C" {
+                    #[link_name = "exit"]
+                    pub fn exit_raw(code: c_int) -> !;
+
+                    #[link_name = "printf"]
+                    pub fn printf_raw(fmt: *const u8, ...) -> c_int;
+                }
+                // Get the location of the function that called panic
+                let loc = Location::caller();
+                let file = loc.file();
+                let line = loc.line();
+                let col  = loc.column();
+                printf_raw(b"%.*s:%u:%u: ERROR: %.*s\n\0".as_ptr(), file.len(), file.as_ptr(), line, col, $fmt.len(), $fmt.as_ptr());
+                exit_raw(69)
+            }
+        };
+    }
+
+    #[macro_export]
     macro_rules! printf {
         ($fmt:literal $($args:tt)*) => {
             use core::ffi::c_int;
@@ -102,6 +146,9 @@ mod ds { // Data Structures
         pub capacity: usize,
     }
 
+    // This makes the panic::Location track the location of the caller rather than this function
+    // if we panic
+    #[track_caller]
     pub unsafe fn array_push<T>(xs: *mut Array<T>, item: T) {
         if (*xs).count >= (*xs).capacity {
             if (*xs).capacity == 0 {
@@ -110,12 +157,21 @@ mod ds { // Data Structures
                 (*xs).capacity *= 2;
             }
             (*xs).items = libc::realloc((*xs).items, (*xs).capacity);
+            if (*xs).items.is_null() {
+                panic!("Failed to allocate memory for array.");
+            }
         }
         *((*xs).items.add((*xs).count)) = item;
         (*xs).count += 1;
     }
 
+    // This makes the panic::Location track the location of the caller rather than this function
+    // if we panic
+    #[track_caller]
     pub unsafe fn array_destroy<T>(xs: *mut Array<T>) {
+        if (*xs).items.is_null() {
+            panic!("Tried to free empty array.");
+        }
         libc::free((*xs).items);
         (*xs).items = ptr::null_mut();
         (*xs).count = 0;
@@ -187,6 +243,8 @@ unsafe extern "C" fn main(_argc: i32, _argv: *mut *mut u8) -> i32 {
         end_drawing();
     }
     close_window();
+    array_destroy(&mut rects);
+    // TODO: Remove this later, this is just for testing the panic
     array_destroy(&mut rects);
     0
 }


### PR DESCRIPTION
Added a `panic!` macro for Crust.

# Usage
```rs
// This makes the panic::Location track the location of the caller rather than this function
// if we panic
#[track_caller]
pub unsafe fn array_destroy<T>(xs: *mut Array<T>) {
    if (*xs).items.is_null() {
        panic!("Tried to free empty array.");
    }
    libc::free((*xs).items);
    (*xs).items = ptr::null_mut();
    (*xs).count = 0;
    (*xs).capacity = 0;
}
```

# Result
```rs
close_window();
array_destroy(&mut rects);
// TODO: Remove this later, this is just for testing the panic
array_destroy(&mut rects);
0
```
```console
INFO: Window closed successfully
main.rs:241:5: ERROR: Tried to free empty array.
```