### PR TITLE
Crust compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 $(OUT): main.rs
-	rustc --edition 2021 -g -C opt-level=z -C link-args=$(ARGS) -C panic="abort" main.rs -o $(OUT)
+	/home/anon/dev/github/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc --edition 2021 -g -C opt-level=z -C link-args=$(ARGS) -C panic="abort" main.rs -o $(OUT)
 
 clean:
 	rm -f main

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="./crust.png" width=200>
 </p>
 
-1. Every function is unsafe.
+1. Use custom build of rustc
 1. No references, only pointers.
 1. No cargo, build with rustc directly.
 1. No std, but libc is allowed.
@@ -15,3 +15,21 @@
 *The list of rules may change. The goal is to make programming in Rust fun.*
 
 Currently used in the [B Compiler Project](https://github.com/tsoding/b).
+
+## Crust Compiler
+
+1. Unsafe checks removed
+1. Variables are mutable by default (`let` rather than `let mut`)
+1. Mutable pointers by default (Can use pointers like `*` instead of `*mut` or `**` rather than `*mut *mut`)
+
+> TODO: public without specifying `pub`
+
+## Setup
+
+```bash
+git clone git@github.com:mbwilding/rust.git --depth=1
+cd rust
+./x.py build
+```
+
+Then update the path in the `Makefile` in this repo to match your clone location


### PR DESCRIPTION
So I made modifications to the rust toolchain.

1. Unsafe checks removed
2. Variables are mutable by default (`let` rather than `let mut`)
3. Mutable pointers by default (Can use pointers like `*` instead of `*mut` or `**` rather than `*mut *mut`)

Just a proof of concept of what Crust could be with a bit of effort.
Would be cool to see azozin implement the pub by default stuff.

Raised this PR mainly to spark something in people. Don't expect it to get merged as it would require a custom pipeline to apply patches to rust and publish releases.

The Crust version of the Rust toolchain is here: https://github.com/mbwilding/rust